### PR TITLE
Adding directory to IaC test config

### DIFF
--- a/iac/action.yml
+++ b/iac/action.yml
@@ -11,7 +11,9 @@ inputs:
   args:
     description: "Additional arguments to pass to Snyk"
   file:
-    description: "File to test"
+    description: "File to test. Do not use if you are using directory"
+  directory:
+    description: "Directory with IaC files to test. Do not use if you are using file"
   json:
     description: "Output a snyk.json file with results if running the test command"
     default: false
@@ -28,5 +30,6 @@ runs:
   - snyk
   - iac
   - ${{ inputs.command }}
+  - ${{ inputs.directory }}
   - ${{ inputs.file }}
   - ${{ inputs.args }}


### PR DESCRIPTION
Some customers want to point Snyk IaC to a directory within their codebase, and we support that use case with the Snyk CLI, but it does not work for this GitHub Action. Therefore, adding a directory field may work and provide us a way to add to the original use case.